### PR TITLE
"If Team Fighting" Crash Fix

### DIFF
--- a/Tactile/Source Code/Game_System/Event_Processor/Event_Processor_Commands.cs
+++ b/Tactile/Source Code/Game_System/Event_Processor/Event_Processor_Commands.cs
@@ -3995,8 +3995,17 @@ namespace Tactile
                 case "Team Fighting":
                     // Value[1] = team id
                     int team_id = process_number(command.Value[1]);
-                    result = (Global.game_system.Battler_1_Id != -1 && Global.game_map.units[Global.game_system.Battler_1_Id].team == team_id) ||
-                        (Global.game_system.Battler_2_Id != -1 && Global.game_map.units[Global.game_system.Battler_2_Id].team == team_id);
+                    bool Battler_1_check = false;
+                    bool Battler_2_check = false;
+                    if (Global.game_map.units.ContainsKey(Global.game_system.Battler_1_Id))
+                    {
+                        Battler_1_check = Global.game_system.Battler_1_Id != -1 && Global.game_map.units[Global.game_system.Battler_1_Id].team == team_id;
+                    }
+                    if (Global.game_map.units.ContainsKey(Global.game_system.Battler_2_Id))
+                    {
+                        Battler_2_check = Global.game_system.Battler_2_Id != -1 && Global.game_map.units[Global.game_system.Battler_2_Id].team == team_id;
+                    }
+                    result = Battler_1_check || Battler_2_check;
                     break;
                 case "Unit at Loc":
                     // Value[1] = x


### PR DESCRIPTION
fixed a bug that causes Tactile to crash if the event "If Team Fighting" is checked after a battle involving a destructible object

Let me know if this is the appropriate way you like to handle pull request. I have found another bug that I would like to submit a fix for, and I suspect I will find a few more before my project is done.